### PR TITLE
Update BUILD_VARIANTS_README.md

### DIFF
--- a/BUILD_VARIANTS_README.md
+++ b/BUILD_VARIANTS_README.md
@@ -1,38 +1,25 @@
 # Klarna Mobile SDK Build Variants
 
-Until the release of Swift 5.1, all Swift modules in a project had to be built with (roughly) the
-same version of Swift.
+With the release of macOS Monterey in October 2021, Apple has decided to drop support to Xcode 12. Because of that, even though we are still providing Xcode 12 builds, only Xcode 13 SDK builds can be officially supported.
 
-While this is not an issue from 5.1 onwards, we offer support for older versions. We also do this
-to (if needed) release versions built against beta versions of Xcode. Support for this is available
-through Cocoapods, Carthage as well as manual (drag-and-drop) integrations.
+Xcode 12 builds will not be available in the future.
 
-We do this by providing multiple builds made with several versions of Xcode as well as fat (device +
-simulator) and slim (device-only) builds.
+Slim (device-only) and fat (device + simulator) versions are available to be used.
+
 
 ## Variants
 
-For this release, we provide:
+Officially supported releases:
 
 | Name | Fat/slim | Xcode Ver. & Build No. | Swift Ver. | Swift Toolchain Ver. |
 | ---- | -------- | ---------------------------- | ---------- | -------------------- |
-| `xcode-12.5.1-fat` | fat | 12.5.1 - 12E507 | 5.4.2| swiftlang-1205.0.28.2 clang-1205.0.19.57 |
-| `xcode-12.5.1-slim` | slim | 12.5.1 - 12E507 | 5.4.2| swiftlang-1205.0.28.2 clang-1205.0.19.57 |
+| `xcode-13.1-slim` | slim | 13.1 - 13A1030d | 5.5.1| swiftlang-1300.0.31.4 clang-1300.0.29.6 |  
 | `xcode-13.1-fat` | fat | 13.1 - 13A1030d | 5.5.1| swiftlang-1300.0.31.4 clang-1300.0.29.6 |
-| `xcode-13.1-slim` | slim | 13.1 - 13A1030d | 5.5.1| swiftlang-1300.0.31.4 clang-1300.0.29.6 |
 
 
-## Cocoapods
+Xcode 12 releases:
 
-This release defaults to using the latest, non-beta version `xcode-13.1-fat`. If you
-want to use a different variant, update your Podfile to use a different subspec. E.g:
-
-
-```ruby
-pod 'KlarnaMobileSDK/xcode-12.5.1-fat', '~> 2.1.3'
-```
-
-```ruby
-pod 'KlarnaMobileSDK/xcode-13.1-fat', '~> 2.1.3'
-```
-
+| Name | Fat/slim | Xcode Ver. & Build No. | Swift Ver. | Swift Toolchain Ver. |
+| ---- | -------- | ---------------------------- | ---------- | -------------------- |
+| `xcode-12.5.1-slim` | slim | 12.5.1 - 12E507 | 5.4.2| swiftlang-1205.0.28.2 clang-1205.0.19.57 |
+| `xcode-12.5.1-fat` | fat | 12.5.1 - 12E507 | 5.4.2| swiftlang-1205.0.28.2 clang-1205.0.19.57 |


### PR DESCRIPTION
Updated BUILD_VARIANTS_README.md contents to state that Apple only supports Xcode 13 and that our support to Xcode 12 is a best-effort and will be discontinued in the future.